### PR TITLE
Verify MAC tag in python, don't write garbage out

### DIFF
--- a/misc/decrypt.py
+++ b/misc/decrypt.py
@@ -11,25 +11,27 @@ from hashlib import pbkdf2_hmac
 BACKUP_STAMP = '2022-04-20-22-59-54-061-user_0'
 INPUT_FILEPATH = os.path.join(BACKUP_STAMP, 'data.tar.gz.enc')
 PASSWORD = b'123456'
-PBKDF_ITERATIONS = 2022
+PBKDF_ITERATIONS = 2020
 KEY_LEN = 32
 FALLBACK_SALT = b'oandbackupx'
 
-with open(BACKUP_STAMP + '.properties') as f:
+with open(BACKUP_STAMP + '.properties', 'r') as f:
     properties = json.load(f)
     iv_bytes = b''.join(map(lambda i: int(i).to_bytes(1, 'big', signed=True), properties['iv']))
 
 key = pbkdf2_hmac(hash_name='sha256',
                   password=PASSWORD,
-                  salt=, FALLBACK_SALT,
+                  salt=FALLBACK_SALT,
                   iterations=PBKDF_ITERATIONS,
                   dklen=KEY_LEN)
 cipher = AES.new(key, AES.MODE_GCM, nonce=iv_bytes)
+
 with open(INPUT_FILEPATH, 'rb') as input_file:
-    with open(os.path.splitext(INPUT_FILEPATH)[0], 'wb') as output_file:
-        # read the file's contents and discard the authentication tag
-        # PyCryptdome doesn't check it implicitly unlike Java Crypto does.
-        # It won't tell if it just decrypted garbage if you don't check the authenticity
-        buffer_in = input_file.read()[:-16]
-        buffer_out = cipher.decrypt(buffer_in)
-        output_file.write(buffer_out)
+    input_bytes = input_file.read()
+
+ciphertext = input_bytes[:-16]
+tag = input_bytes[-16:]
+plaintext = cipher.decrypt_and_verify(ciphertext, tag)
+
+with open(os.path.splitext(INPUT_FILEPATH)[0], 'wb') as output_file:
+    output_file.write(plaintext)


### PR DESCRIPTION
Uses verify to check if the password is correct and input valid, otherwise throw `ValueError: MAC check failed`, the script will exit without creating the output file in this case.

Also fix the syntax error on salt and adjust the kdf interations to match NeoBackup (8.3).